### PR TITLE
adding config.py to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 __pycache__
 env
+config.py


### PR DESCRIPTION
adding config.py to the gitignore file to prevent accidentally uploading my private API keys for google and strava.